### PR TITLE
chore: update to numbat 0.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 target
 forza
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Maciej Małecki <me@mmalecki.com>"]
 [dependencies]
 timer = "0.1.6"
 rustc-serialize = "0.3.21"
-numbat = "0.2.0"
+numbat = "0.3.0"
 chrono = "0.2.25"
 serde_json = "0.8.3"
 libc = "0.2.18"

--- a/src/plugins/load_average.rs
+++ b/src/plugins/load_average.rs
@@ -35,9 +35,9 @@ impl<'a> LoadAverage<'a> {
     let ret = get_load_average();
     match ret {
       Ok(loads) => {
-        self.emitter.emit_f64("load-average.1", loads[0]);
-        self.emitter.emit_f64("load-average.5", loads[1]);
-        self.emitter.emit_f64("load-average.15", loads[2]);
+        self.emitter.emit("load-average.1", loads[0]);
+        self.emitter.emit("load-average.5", loads[1]);
+        self.emitter.emit("load-average.15", loads[2]);
       },
       Err(e) => panic!("getloadavg() failed: {}", e)
     }

--- a/src/plugins/memory.rs
+++ b/src/plugins/memory.rs
@@ -54,7 +54,7 @@ impl<'a> Memory<'a> {
       cached.expect("expected Cached") -
       buffers.expect("expected Buffers");
 
-    self.emitter.emit_f64("memory", used as f64 / t as f64);
+    self.emitter.emit("memory", used as f64 / t as f64);
   }
 }
 


### PR DESCRIPTION
Bumped dep in Cargo.toml.
Replaced all uses of `emit_f64()` with `emit()`.
Added Cargo.lock to the git ignore.